### PR TITLE
Fix #7 - error when no actions are present

### DIFF
--- a/custom_components/olarm_sensors/olarm_api.py
+++ b/custom_components/olarm_sensors/olarm_api.py
@@ -59,6 +59,10 @@ class OlarmApi:
                     f"https://apiv4.olarm.co/api/v4/devices/{self.device_id}/actions",
                     headers=self.headers,
                 ) as response:
+                    if response.status == 404:
+                        LOGGER.debug("actions endpoint returned 404")
+                        return return_data
+
                     changes = await response.json()
                     for change in changes:
                         if (


### PR DESCRIPTION
It seems like the API only returns actions that happened in the last few days.
So if you didn't arm or disarm the alarm in a few days, the endpoint returns a 404.
Fixes #7 