### PR TITLE
Fixed blank zone and bypass labels

### DIFF
--- a/custom_components/olarm_sensors/olarm_api.py
+++ b/custom_components/olarm_sensors/olarm_api.py
@@ -121,9 +121,9 @@ class OlarmApi:
 
             last_changed = last_changed.strftime("%a %d %b %Y %X")
 
-            if zone < len(olarm_zones["zonesLabels"]) and (
-                olarm_zones["zonesLabels"][zone]
-                or olarm_zones["zonesLabels"][zone] == ""
+            if (zone < len(olarm_zones["zonesLabels"])
+                and olarm_zones["zonesLabels"][zone]
+                and olarm_zones["zonesLabels"][zone].strip() != ""
             ):
                 zone_name = olarm_zones["zonesLabels"][zone]
                 zone_type = olarm_zones["zonesTypes"][zone]
@@ -191,9 +191,9 @@ class OlarmApi:
 
             last_changed = last_changed.strftime("%a %d %b %Y %X")
 
-            if zone < len(olarm_zones["zonesLabels"]) and (
-                olarm_zones["zonesLabels"][zone]
-                or olarm_zones["zonesLabels"][zone] == ""
+            if (zone < len(olarm_zones["zonesLabels"])
+                and olarm_zones["zonesLabels"][zone]
+                and olarm_zones["zonesLabels"][zone].strip() != ""
             ):
                 zone_name = olarm_zones["zonesLabels"][zone]
 


### PR DESCRIPTION
My alarm panel supports 64 zones, and is not close to being used to full capacity. That means there are quite a few zones that are blank. I was receiving warnings for 'non-unique' sensor naming. When importing the blank zones they were all being 'collapsed' into a single sensor.

```
2023-04-08 12:31:58.149 ERROR (MainThread) [homeassistant.components.binary_sensor] Platform olarm_sensors does not generate unique IDs. ID <REMOVED ALARMID>_ already exists - ignoring binary_sensor.home
2023-04-08 12:31:58.151 ERROR (MainThread) [homeassistant.components.binary_sensor] Platform olarm_sensors does not generate unique IDs. ID <REMOVED ALARMID>_ already exists - ignoring binary_sensor.home
2023-04-08 12:31:58.151 ERROR (MainThread) [homeassistant.components.binary_sensor] Platform olarm_sensors does not generate unique IDs. ID <REMOVED ALARMID>_ already exists - ignoring binary_sensor.home
2023-04-08 12:31:58.151 ERROR (MainThread) [homeassistant.components.binary_sensor] Platform olarm_sensors does not generate unique IDs. ID <REMOVED ALARMID>_ already exists - ignoring binary_sensor.home
2023-04-08 12:31:58.152 ERROR (MainThread) [homeassistant.components.binary_sensor] Platform olarm_sensors does not generate unique IDs. ID <REMOVED ALARMID>_ already exists - ignoring binary_sensor.home
2023-04-08 12:31:58.152 ERROR (MainThread) [homeassistant.components.binary_sensor] Platform olarm_sensors does not generate unique IDs. ID <REMOVED ALARMID>_ already exists - ignoring binary_sensor.home
2023-04-08 12:31:58.153 ERROR (MainThread) [homeassistant.components.binary_sensor] Platform olarm_sensors does not generate unique IDs. ID <REMOVED ALARMID>_ already exists - ignoring binary_sensor.home
2023-04-08 12:31:58.153 ERROR (MainThread) [homeassistant.components.binary_sensor] Platform olarm_sensors does not generate unique IDs. ID <REMOVED ALARMID>_ already exists - ignoring binary_sensor.home
2023-04-08 12:31:58.153 ERROR (MainThread) [homeassistant.components.binary_sensor] Platform olarm_sensors does not generate unique IDs. ID <REMOVED ALARMID>_ already exists - ignoring binary_sensor.home
2023-04-08 12:31:58.154 ERROR (MainThread) [homeassistant.components.binary_sensor] Platform olarm_sensors does not generate unique IDs. ID <REMOVED ALARMID>_ already exists - ignoring binary_sensor.home
```

This PR fixes the boolean expression.