### PR TITLE
Comment out writing services.yaml to fix init

### DIFF
--- a/custom_components/olarm_sensors/__init__.py
+++ b/custom_components/olarm_sensors/__init__.py
@@ -146,11 +146,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             device["deviceId"],
         )
 
-    with open(
-        file=os.path.join(path, "services.yaml"), mode="w+", encoding="utf8"
-    ) as service_file:
-        for line in filedata:
-            service_file.write(line)
+    # with open(
+    #     file=os.path.join(path, "services.yaml"), mode="w+", encoding="utf8"
+    # ) as service_file:
+    #     for line in filedata:
+    #         service_file.write(line)
 
     # Forwarding the setup for the other Home Assistant platforms.
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)


### PR DESCRIPTION
Please note that there now may not be the correct info for each Olarm Service under the services tab. There will also now no longer be the fill example data.